### PR TITLE
add sourcemaps to sass gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ const sass = require('gulp-sass');
 const child = require('child_process');
 const gutil = require('gulp-util');
 const browserSync = require('browser-sync');
+const sourcemaps = require('gulp-sourcemaps');
 
 // PATHS
 const config = {
@@ -30,10 +31,12 @@ const config = {
 //Sass to CSS Task
 gulp.task('css', () => {
   gulp.src(config.paths.cssFiles)
+      .pipe(sourcemaps.init())
       .pipe(sass({
         includePaths: ['node_modules/susy/sass']
       }).on('error', sass.logError))
       .pipe(concat('main.css'))
+      .pipe(sourcemaps.write())
       .pipe(gulp.dest('./_src/assets/css'));
 });
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-if": "^2.0.1",
     "gulp-sass": "^2.3.2",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-uglify": "^2.0.0",
     "gulp-useref": "^3.1.2",
     "gulp-util": "^3.0.7",


### PR DESCRIPTION
Added gulp-sourcemaps dependency to the project.  This allows us to map back to the originating sass source file. Works with javascript as well. @dusenberrymw @deroneriksson 