### PR TITLE
[MINOR] Add roadmap information for 0.12 release

### DIFF
--- a/0.12.0-incubating/release_notes.md
+++ b/0.12.0-incubating/release_notes.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: SystemML 0.12.0-incubating Release Notes
+description: Project Release Notes
+group: nav-right
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+<br/><br/><br/>
+
+The **Apache SystemML 0.12.0-incubating release** was approved on February 7, 2017. It is the fourth release of Apache SystemML since it
+became an incubator project on November 2nd, 2015. Updates have been made to the project in several areas, as detailed below.
+
+
+### New Features
+- Support pip install of new python package
+- Allow NumPy arrays, Pandas DataFrame and SciPy matrices as input to MLContext
+- Improve SystemML Python DSL for NumPy
+- Updated build for Spark 1.6.0
+- DML utility script to shuffle input dataset
+
+### Experimental Features / Algorithms
+- GPU Enhancements
+
+### Various Fixes
+* Several bug fixes for diverse issues
+
+
+

--- a/_src/roadmap.html
+++ b/_src/roadmap.html
@@ -63,6 +63,25 @@ limitations under the License.
       <h2>Prior Releases</h2>
       <ul>
         <li>
+          <strong>SystemML 0.12.0-incubating (<a href="https://github.com/apache/incubator-systemml-website/blob/master/0.12.0-incubating/release_notes.md">released in February, 2017</a>)</strong>
+          <ul>
+            <li>Support pip install of new python package</li>
+            <li>Allow NumPy arrays, Pandas DataFrame and SciPy matrices as input to MLContext</li>
+            <li>Improve SystemML Python DSL for NumPy</li>
+			<li>Updated build for Spark 1.6.0</li>
+			<li>DML utility script to shuffle input dataset</li>
+          </ul>
+        </li>
+        <li>
+          Experimental Features / Algorithms
+          <ul>
+            <li>GPU Enhancements</li>
+          </ul>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
           <strong>SystemML 0.11.0-incubating (<a href="https://github.com/apache/incubator-systemml-website/blob/master/0.11.0-incubating/release_notes.md">released in November, 2016</a>)</strong>
           <ul>
             <li>SystemML frames</li>


### PR DESCRIPTION
Added roadmap information for 0.12 release following pattern observed for previous release.  Content based on manually checking commits since 0.11 release due to inconsistent fixed-in version of resolved JIRAs.