### PR TITLE
[MINOR] Update download page and button for release 0.12

### DIFF
--- a/_src/_data/project.yml
+++ b/_src/_data/project.yml
@@ -50,7 +50,7 @@ issues_list_archive_markmail:
 jira: SYSTEMML
 
 release_name: systemml
-release_version: 0.11.0-incubating
+release_version: 0.12.0-incubating
 
 source_repository: https://git-wip-us.apache.org/repos/asf/incubator-systemml.git
 source_repository_mirror: https://github.com/apache/incubator-systemml

--- a/_src/_includes/themes/apache/home.html
+++ b/_src/_includes/themes/apache/home.html
@@ -26,7 +26,7 @@ limitations under the License.
       <p>A machine learning platform optimal for big data</p>
     </div>
     <div class="col col-12 content-group button-group">
-      <a class="button button-primary" href="download.html">Download SystemML 0.11.0-incubating</a>
+      <a class="button button-primary" href="download.html">Download SystemML {{ site.data.project.release_version }}</a>
     </div>
   </div>
   <!-- video background  -->

--- a/_src/download.html
+++ b/_src/download.html
@@ -39,7 +39,7 @@ limitations under the License.
       <p>Apache SystemML is released as a source artifact. Binary artifacts (including the ones available in Maven) are made available for your convenience. You will be prompted for a mirror - if the file is not found on yours, please be patient, as it may take 24 hours to reach all mirrors. Apache SystemML is distributed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, version 2.0</a>. </p>
     </div>
     <div class="col col-12 content-group">
-      <h2>Download SystemML {{ site.data.project.release_version }}</h2>
+      <h2>Download SystemML {{ site.data.project.release_version }} for Spark 1.6</h2>
     </div>
 
     <div class="col col-12 content-group row">
@@ -81,7 +81,7 @@ limitations under the License.
           <p>Instructions for checking hashes and signatures is described on the <a href="http://www.apache.org/info/verification.html" target="_blank">Verifying Apache Software Foundation Releases</a> page.</p>
 
           <h3>Nightly Experimental Builds</h3>
-          <p>Nighly experimental builds can be obtained from <a href="https://sparktc.ibmcloud.com/repo/latest/" target="_blank">our nightly build</a> page.</p>
+          <p>Nighly experimental builds for Spark 2.x can be obtained from <a href="https://sparktc.ibmcloud.com/repo/latest/" target="_blank">our nightly build</a> page.</p>
 
           <h3>Bleeding-Edge</h3>
           <p>You can also retrieve the source files from our <a href="https://github.com/apache/incubator-systemml" target="_blank">Git repository</a> and create a bleeding-edge build by typing:</p>

--- a/_src/download.html
+++ b/_src/download.html
@@ -81,7 +81,7 @@ limitations under the License.
           <p>Instructions for checking hashes and signatures is described on the <a href="http://www.apache.org/info/verification.html" target="_blank">Verifying Apache Software Foundation Releases</a> page.</p>
 
           <h3>Nightly Experimental Builds</h3>
-          <p>Nighly experimental builds for Spark 2.x can be obtained from <a href="https://sparktc.ibmcloud.com/repo/latest/" target="_blank">our nightly build</a> page.</p>
+          <p>Nightly experimental builds for Spark 2.x can be obtained from <a href="https://sparktc.ibmcloud.com/repo/latest/" target="_blank">our nightly build</a> page.</p>
 
           <h3>Bleeding-Edge</h3>
           <p>You can also retrieve the source files from our <a href="https://github.com/apache/incubator-systemml" target="_blank">Git repository</a> and create a bleeding-edge build by typing:</p>


### PR DESCRIPTION
Updated release version to automatically point to 0.12 release links.  Updated button text so that it picks up release version.  Also added text to distinguish spark versions for current release and nightly build.