### PR TITLE
[SYSTEMML-1256] Add download link for previous releases

### DIFF
--- a/_src/download.html
+++ b/_src/download.html
@@ -112,7 +112,7 @@ mvn clean package</pre>
 &lt;/dependency&gt;</pre>
  
           <h3>Previous Releases</h3>
-          <p>All previous release of Apache SystemML can be obtained from <a href="http://archive.apache.org/dist/incubator/systemml/" target="_blank">archives</a>.</p>
+          <p>All previous releases of Apache SystemML can be obtained from <a href="http://archive.apache.org/dist/incubator/systemml/" target="_blank">archives</a>.</p>
        </div>
     </div>
   </div>

--- a/_src/download.html
+++ b/_src/download.html
@@ -110,7 +110,10 @@ mvn clean package</pre>
   &lt;artifactId&gt;systemml&lt;/artifactId&gt;
   &lt;version&gt;{{ site.data.project.release_version }}&lt;/version&gt;
 &lt;/dependency&gt;</pre>
-        </div>
+ 
+          <h3>Previous Releases</h3>
+          <p>All previous release of Apache SystemML can be obtained from <a href="http://archive.apache.org/dist/incubator/systemml/" target="_blank">archives</a>.</p>
+       </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Added note with link to http://archive.apache.org/dist/incubator/systemml/ at bottom of download page for convenient access to previous systemml releases.