### PR TITLE
Update project, roadmap, release notes for 0.14

### DIFF
--- a/0.14.0-incubating/release_notes.md
+++ b/0.14.0-incubating/release_notes.md
@@ -34,7 +34,6 @@ became an incubator project on November 2nd, 2015. Updates have been made to the
 
 ### Experimental Features
 - New Code Generation capabilities for automatic operator fusion (basic code generator, compiler integration, runtime integration, in-memory source code compilation, extended explain tool, support for right indexing and replace in cellwise and row aggregate templates, support for row, column, or no aggregation in rowwise template).  Note code generation provides significant performance gains with fewer read/write intermediates, reduced scans of inputs and intermediates, and enhanced sparsity exploitation.  To enable this feature, set `codegen.enabled` property to `true` in SystemML-config.xml file.
-- New layers for Deep Learning DML Library (batch normalization, spatial batch normalization, 1D/2D "Scale & Shift")
 - New instructions and operators for GPU support (relu\_maxpooling, conv2d\_bias\_add, bias\_multiply)
 
 ### Removals

--- a/0.14.0-incubating/release_notes.md
+++ b/0.14.0-incubating/release_notes.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: SystemML 0.14.0-incubating Release Notes
+description: Project Release Notes
+group: nav-right
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+<br/><br/><br/>
+
+The **Apache SystemML 0.14.0-incubating release** was approved on May 8, 2017. It is the sixth release of Apache SystemML since it
+became an incubator project on November 2nd, 2015. Updates have been made to the project in several areas, as detailed below.
+
+
+### New Features and Capabilities
+- Runtime feature extensions (new libsvm-binary data converters, parfor spark buffer pool handling, parfor block partitioning of fixed size batches of rows or columns, native dataset support in parfor spark datapartition-execute)
+- Compiler feature extensions (improved parfor execution type selection, improved literal replacement for nrow/ncol, simplified instruction generation across back-ends, consolidated static/dynamic rewrite utilities)
+
+### Experimental Features
+- New Code Generation capabilities for automatic operator fusion (basic code generator, compiler integration, runtime integration, in-memory source code compilation, extended explain tool, support for right indexing and replace in cellwise and row aggregate templates, support for row, column, or no aggregation in rowwise template).  Note code generation provides significant performance gains with fewer read/write intermediates, reduced scans of inputs and intermediates, and enhanced sparsity exploitation.  To enable this feature, set `codegen.enabled` property to `true` in SystemML-config.xml file.
+- New layers for Deep Learning DML Library (batch normalization, spatial batch normalization, 1D/2D "Scale & Shift")
+- New instructions and operators for GPU support (relu\_maxpooling, conv2d\_bias\_add, bias\_multiply)
+
+### Removals
+- Removed support for Java 6 and Java 7
+- Removed parfor perftesttool and cost estimator
+
+### Various Fixes
+* Bug fixes for diverse issues.  See [JIRA release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12319522&version=12340322) for complete list.

--- a/_src/_data/project.yml
+++ b/_src/_data/project.yml
@@ -50,7 +50,7 @@ issues_list_archive_markmail:
 jira: SYSTEMML
 
 release_name: systemml
-release_version: 0.13.0-incubating
+release_version: 0.14.0-incubating
 
 source_repository: https://git-wip-us.apache.org/repos/asf/incubator-systemml.git
 source_repository_mirror: https://github.com/apache/incubator-systemml

--- a/_src/roadmap.html
+++ b/_src/roadmap.html
@@ -39,8 +39,10 @@ limitations under the License.
       <h2>Planned for Future SystemML 1.0</h2>
       <ul>
         <li>Rigorous Performance and Scalability Testing (Bug Fixes)</li>
-        <li>Remove Deprecated APIs</li>
-        <li>Remove Deprecated Functions</li>
+        <li>Remove Deprecated APIs/Functions</li>
+        <li>Compression (additional operations)</li>
+        <li>Decomposition Algorithms</li>
+        <li>Experimental Features Improvements (Native BLAS, Single GPU, Deep Learning, Code Generation, Python DSL)
       </ul>
     </div>
 
@@ -48,19 +50,50 @@ limitations under the License.
       <h2>Planned for Future Releases</h2>
       <ul>
         <li>Completion of Prior Experimental Features</li>
-        <li>New Algorithms: Non-linear SVMs, Solvers, Decomposition, Inversion, etc.</li>
-        <li>DSLs (e.g. Scala, Python) and Common DSL Architecture</li>
+        <li>New Algorithms</li>
+        <li>Common DSL Architecture</li>
         <li>R Interfaces: R DSL and R Wrappers</li>
         <li>Native Zeppelin Notebook Support</li>
-        <li>Code Generation</li>
         <li>Sum Product Optimizations</li>
         <li>Tree-based Data Structures</li>
         <li>Global Dataflow Optimizations</li>
+        <li>Tooling</li>
       </ul>
     </div>
 
     <div class="col col-12">
       <h2>Current Release</h2>
+      <ul>
+        <li>
+          <strong>SystemML 0.14.0-incubating (<a href="https://github.com/apache/incubator-systemml-website/blob/master/0.14.0-incubating/release_notes.md">released</a> in May, 2017)
+          <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12319522&version=12340322">details</a></strong>
+          <ul>
+            <li>Runtime feature extensions (new libsvm-binary data converters, parfor spark buffer pool handling, parfor block partitioning of fixed size batches of rows or columns, native dataset support in parfor spark datapartition-execute)</li>
+            <li>Compiler feature extensions (improved parfor execution type selection, improved literal replacement for nrow/ncol, simplified instruction generation across back-ends, consolidated static/dynamic rewrite utilities)</li>
+          </ul>
+        </li>
+        <li>
+          Experimental Features
+          <ul>
+            <li>New Code Generation capabilities for automatic operator fusion (basic code generator, compiler integration, runtime integration, in-memory source code compilation, extended explain tool, support for right indexing and replace in cellwise and row aggregate templates, support for row, column, or no aggregation in rowwise template).
+            Note code generation provides significant performance gains with fewer read/write intermediates, reduced scans of inputs and intermediates, and enhanced sparsity exploitation. To enable this feature, set codegen.enabled property to true in SystemML-config.xml file.</li>
+            <li>New layers for Deep Learning DML Library (batch normalization, spatial batch normalization, 1D/2D "Scale & Shift")</li>
+            <li>New instructions and operators for GPU support (relu_maxpooling, conv2d_bias_add, bias_multiply)</li>
+          </ul>
+        </li>
+        <li>
+          Removals
+          <ul>
+            <li>Removed support for Java 6 and Java 7</li>
+            <li>Removed parfor perftesttool and cost estimator</li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+
+    <div class="col col-12">
+      <h2>Prior Releases</h2>
+  
       <ul>
         <li>
           <strong>SystemML 0.13.0-incubating (<a href="https://github.com/apache/incubator-systemml-website/blob/master/0.13.0-incubating/release_notes.md">released</a> in March, 2017)
@@ -100,10 +133,7 @@ limitations under the License.
           </ul>
         </li>
       </ul>
-    </div>
 
-    <div class="col col-12">
-      <h2>Prior Releases</h2>
       <ul>
         <li>
           <strong>SystemML 0.12.0-incubating (<a href="https://github.com/apache/incubator-systemml-website/blob/master/0.12.0-incubating/release_notes.md">released</a> in February, 2017)

--- a/_src/roadmap.html
+++ b/_src/roadmap.html
@@ -77,7 +77,6 @@ limitations under the License.
           <ul>
             <li>New Code Generation capabilities for automatic operator fusion (basic code generator, compiler integration, runtime integration, in-memory source code compilation, extended explain tool, support for right indexing and replace in cellwise and row aggregate templates, support for row, column, or no aggregation in rowwise template).
             Note code generation provides significant performance gains with fewer read/write intermediates, reduced scans of inputs and intermediates, and enhanced sparsity exploitation. To enable this feature, set codegen.enabled property to true in SystemML-config.xml file.</li>
-            <li>New layers for Deep Learning DML Library (batch normalization, spatial batch normalization, 1D/2D "Scale & Shift")</li>
             <li>New instructions and operators for GPU support (relu_maxpooling, conv2d_bias_add, bias_multiply)</li>
           </ul>
         </li>


### PR DESCRIPTION
Changed project version to 0.14 so download links reference 0.14 artifacts when officially released and uploaded to mirrors.  Added 0.14.0-incubating release notes and updated roadmap including lists for future releases.