### PR TITLE
[MINOR] Ensure direction for 'What is SystemML?' across browsers

### DIFF
--- a/_src/_includes/themes/apache/home.html
+++ b/_src/_includes/themes/apache/home.html
@@ -57,7 +57,7 @@ limitations under the License.
       <!-- bdi tag prevents reverse punctuation when rtl direction property is applied -->
       <h2><bdi>What is SystemML?&lrm;</bdi></h2>
 
-      <p>Apache SystemML provides an optimal workplace for machine learning using big data. It can be run on top of Apache Spark, where it automatically scales your data, line by line, determining whether your code should be run on the driver or an Apache Spark cluster. Future SystemML developments include additional deep learning with GPU capabilities such as importing and running neural network architectures and pre-trained models for training.</p>
+      <p>Apache SystemML provides an optimal workplace for machine learning using big data. It can be run on top of Apache Spark, where it automatically scales your data, line by line, determining whether your code should be run on the driver or an Apache Spark cluster. Future SystemML developments include additional deep learning with GPU capabilities such as importing and running neural network architectures and pre-trained models for training.&lrm;</p>
       <p><a href="#systemml-video" class="modal-trigger jq-modal-trigger"><span class="icon play-button"></span><span>Learn more about SystemML</span></a></p>
     </div>
   </div>

--- a/_src/_includes/themes/apache/home.html
+++ b/_src/_includes/themes/apache/home.html
@@ -55,7 +55,7 @@ limitations under the License.
     </div>
     <div class="col col-6 content-group content-group--more-padding">
       <!-- bdi tag prevents reverse punctuation when rtl direction property is applied -->
-      <h2><bdi>What is SystemML?</bdi></h2>
+      <h2><bdi>What is SystemML?&lrm;</bdi></h2>
 
       <p>Apache SystemML provides an optimal workplace for machine learning using big data. It can be run on top of Apache Spark, where it automatically scales your data, line by line, determining whether your code should be run on the driver or an Apache Spark cluster. Future SystemML developments include additional deep learning with GPU capabilities such as importing and running neural network architectures and pre-trained models for training.</p>
       <p><a href="#systemml-video" class="modal-trigger jq-modal-trigger"><span class="icon play-button"></span><span>Learn more about SystemML</span></a></p>


### PR DESCRIPTION
For certain browsers (e.g., IE 11), the question mark was observed to be displayed before the text 'What is SystemML'.  This change ensures '?' is displayed to right.  Special thanks to @deroneriksson for finding `&lrm;` marker.