### PR TITLE
[SYSTEMML-1619] Remove nightly builds link from download page

### DIFF
--- a/_src/download.html
+++ b/_src/download.html
@@ -86,9 +86,6 @@ limitations under the License.
           <p>Instructions for checking hashes and signatures is described on the <a href="http://www.apache.org/info/verification.html" target="_blank">Verifying Apache Software Foundation Releases</a> page.</p>
 
 
-          <h3>Nightly Experimental Builds</h3>
-          <p>Nightly experimental builds for Spark 2.x can be obtained from <a href="https://sparktc.ibmcloud.com/repo/latest/" target="_blank">our nightly build</a> page.</p>
-
           <h3>Bleeding-Edge</h3>
           <p>You can also retrieve the source files from our <a href="https://github.com/apache/incubator-systemml" target="_blank">Git repository</a> and create a bleeding-edge build by typing:</p>
 


### PR DESCRIPTION
Removed 'Nightly Experimental Builds' section from download page which contained link to https://sparktc.ibmcloud.com/repo/latest/ as per Apache Release Policy at http://www.apache.org/legal/release-policy.html#what.