### PR TITLE
[SYSTEMML-1618] Use https for KEYS, md5, asc on download page

### DIFF
--- a/_src/download.html
+++ b/_src/download.html
@@ -52,28 +52,28 @@ limitations under the License.
           </tr>
           <tr>
             <td><a href="http://www.apache.org/dyn/closer.lua/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.tgz" target="_blank"> {{ site.data.project.release_name }}-{{ site.data.project.release_version }} (Binary tgz)</a></td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.tgz.md5">MD5</a> </td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.tgz.asc">ASC</a></td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.tgz.md5">MD5</a> </td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.tgz.asc">ASC</a></td>
           </tr>
           <tr>
             <td><a href="http://www.apache.org/dyn/closer.lua/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.zip" target="_blank">{{ site.data.project.release_name }}-{{ site.data.project.release_version }} (Binary zip)</a></td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.zip.md5">MD5</a></td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.zip.asc">ASC</a></td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.zip.md5">MD5</a></td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-bin.zip.asc">ASC</a></td>
           </tr>
           <tr>
             <td><a href="http://www.apache.org/dyn/closer.lua/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.tgz" target="_blank">{{ site.data.project.release_name }}-{{ site.data.project.release_version }} (Source tgz)</a></td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.tgz.md5">MD5</a></td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.tgz.asc">ASC</a></td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.tgz.md5">MD5</a></td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.tgz.asc">ASC</a></td>
           </tr>
           <tr>
             <td><a href="http://www.apache.org/dyn/closer.lua/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.zip" target="_blank">{{ site.data.project.release_name }}-{{ site.data.project.release_version }} (Source zip)</a></td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.zip.md5">MD5</a></td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.zip.asc">ASC</a></td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.zip.md5">MD5</a></td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-src.zip.asc">ASC</a></td>
           </tr>
           <tr>
             <td><a href="http://www.apache.org/dyn/closer.lua/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-python.tgz" target="_blank">{{ site.data.project.release_name }}-{{ site.data.project.release_version }} (Python package .tgz)</a></td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-python.tgz.md5">MD5</a></td>
-            <td><a href="http://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-python.tgz.asc">ASC</a></td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-python.tgz.md5">MD5</a></td>
+            <td><a href="https://www.apache.org/dist/incubator/systemml/{{ site.data.project.release_version }}/systemml-{{ site.data.project.release_version }}-python.tgz.asc">ASC</a></td>
           </tr>
 
           <tr>
@@ -83,7 +83,9 @@ limitations under the License.
           </tr>
           </table>
 
-          <p>Instructions for checking hashes and signatures is described on the <a href="http://www.apache.org/info/verification.html" target="_blank">Verifying Apache Software Foundation Releases</a> page.</p>
+          <p>Instructions for checking hashes and signatures is described on the <a href="http://www.apache.org/info/verification.html" target="_blank">Verifying Apache Software Foundation Releases</a> page.
+		  These <a href="https://www.apache.org/dist/incubator/systemml/KEYS" target="_blank">KEYS</a> can be used to <a href="http://www.apache.org/dyn/closer.cgi#verify" target="_blank">verify</a> the integrity of the downloaded artifact using hash (.md5) or PGP signature (.asc).
+		  </p>
 
 
           <h3>Bleeding-Edge</h3>


### PR DESCRIPTION
Switched to https for .md5 and .asc download links.  Also added link to KEYS file from main distribution site.